### PR TITLE
Clarify setting config with CELERY_CONFIG_MODULE

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -17,21 +17,50 @@ The latest stable can be installed via pip:
 Usage
 -----
 
+(Usage) as a module
+^^^^^^^^^^^^^^^^^^^
+
 To set configuration values, you must set an environment variables for each top-level key (`as documented in the Celery documentation <https://docs.celeryproject.org/en/latest/userguide/configuration.html#configuration>`_).
 
 Each environment variable is prefixed with ``NEW_CELERY_``, followed by the config key name in lowercase. The value for each environment variable must be valid YAML (or JSON--remember that JSON is a subset of YAML).
 
-For example, setting these variables in the shell looks like:
+You must also set the environment variable ``CELERY_CONFIG_MODULE`` to ``new_celery_config.as_module`` to enable Celery to read all of the other environment variables that you have set.
+
+For example, setting these environment variables in the shell looks like:
 
 .. code:: bash
 
-    export BROKER_URL='transport://userid:password@hostname:port/virtual_host'
+    export CELERY_CONFIG_MODULE=new_celery_config.as_module
+    export NEW_CELERY_broker_url='transport://userid:password@hostname:port/virtual_host'
     export NEW_CELERY_broker_transport_options='{"visibility_timeout": 36000}'
+
+And in your Python code, initialize the Celery object as follows:
+
+.. code:: python
+
+    app = Celery()
+
+If you want to change the name of the ``CELERY_CONFIG_MODULE``, you can use the ``config_from_envvar`` function. For example:
+
+.. code:: bash
+
+    export CELERY_CONFIG_MODULE=new_celery_config.as_module
+
+.. code:: python
+
+    app.config_from_envvar("ARBITRARY_CELERY_CONFIG_MODULE")
+
+You can test that the configuration works by examining the ``app.conf`` object:
+
+.. code:: python
+
+    print(app.conf.broker_transport_options)
+    # prints out {'visibility_timeout': 36000}
 
 Usage (as an object)
 ^^^^^^^^^^^^^^^^^^^^
 
-Then, when you create your Celery object in code, you can pass it a ``new_celery_config.Config`` object. For example:
+Celery also accepts configuration in the form of a Python object. If you prefer this way, you can give Celery a ``new_celery_config.Config`` object. For example:
 
 .. code:: python
 
@@ -41,29 +70,6 @@ Then, when you create your Celery object in code, you can pass it a ``new_celery
     app = Celery()
     app.config_from_object(new_celery_config.Config())
 
-
-and you can test that the configuration works by examining the ``app.conf`` object:
-
-.. code:: python
-
-    print(app.conf.broker_transport_options)
-    # prints out {'visibility_timeout': 36000}
-
-(Usage) as a module
-^^^^^^^^^^^^^^^^^^^
-
-Celery also accepts configuration from a module with top-level variables mapping to config keys. The location of this module can be set via an environment variable.
-
-If your existing configuration is already in an module, then your code probably already looks like:
-
-.. code:: python
-
-    app = Celery()
-    app.config_from_envvar("ARBITRARY_CELERY_CONFIG_MODULE")
-
-where the value of ``ARBITRARY_CELERY_CONFIG_MODULE`` is something like ``your_project.celeryconfig``.
-
-If you don't want to change your Python code to read, then just set your ``ARBITRARY_CELERY_CONFIG_MODULE`` environment variable to ``new_celery_config.as_module`` and everything will work as expected.
 
 Contributing changes to ``new_celery_config``
 ---------------------------------------------

--- a/README.rst
+++ b/README.rst
@@ -44,7 +44,7 @@ If you want to change the name of the ``CELERY_CONFIG_MODULE``, you can use the 
 
 .. code:: bash
 
-    export CELERY_CONFIG_MODULE=new_celery_config.as_module
+    export ARBITRARY_CELERY_CONFIG_MODULE=new_celery_config.as_module
 
 .. code:: python
 

--- a/tests/test_as_module.py
+++ b/tests/test_as_module.py
@@ -10,7 +10,7 @@ BROKER_URL = "transport://userid:password@hostname:port/virtual_host"
 
 S3_BUCKET = "bucket"
 
-os.environ["ARBITRARY_CELERY_CONFIG_MODULE"] = "new_celery_config.as_module"
+os.environ["CELERY_CONFIG_MODULE"] = "new_celery_config.as_module"
 os.environ["NEW_CELERY_broker_transport_options"] = BROKER_TRANSPORT_OPTIONS
 os.environ["NEW_CELERY_broker_url"] = BROKER_URL
 os.environ["NEW_CELERY_s3_bucket"] = S3_BUCKET
@@ -29,7 +29,6 @@ class TestAsModule(unittest.TestCase):
     def test_works_with_celery(self):  # pylint: disable-duplicate-code
         """Test that Celery understands these objects."""
         app = Celery()
-        app.config_from_envvar("ARBITRARY_CELERY_CONFIG_MODULE")
         self.assertEqual(
             app.conf.broker_transport_options, dict(visibility_timeout=36000)
         )


### PR DESCRIPTION
We don't need to specify a custom `CELERY_CONFIG_MODULE` environment variable name. The docs and tests should reflect that.