### PR TITLE
Bugfix: Properly handle false values

### DIFF
--- a/new_celery_config/__init__.py
+++ b/new_celery_config/__init__.py
@@ -30,15 +30,6 @@ def _load_key(environment_key: str):
     return ""
 
 
-def _load_value(serialized: str):
-    """Deserializes YAML and swallows exceptions."""
-    try:
-        deserialized = yaml.safe_load(serialized)
-    except yaml.YAMLError:
-        return ""
-    return deserialized
-
-
 class Config:  # pylint: disable=too-few-public-methods
     """A Celery config object. For each key, it reads values as YAML in environment variables."""
 
@@ -49,6 +40,9 @@ class Config:  # pylint: disable=too-few-public-methods
         for environment_key, serialized_value in environ.items():
             key = _load_key(environment_key)
             if key:
-                value = _load_value(serialized_value)
-                if value:
+                try:
+                    value = yaml.safe_load(serialized_value)
+                except yaml.YAMLError:
+                    continue
+                else:
                     setattr(self, key, value)

--- a/tests/test_new_celery_config.py
+++ b/tests/test_new_celery_config.py
@@ -46,6 +46,7 @@ class TestNewCeleryConfig(unittest.TestCase):
                 NEW_CELERY_broker_url=BROKER_URL,
                 NEW_CELERY_s3_bucket=S3_BUCKET,
                 NEW_CELERY_broker_transport_options=BROKER_TRANSPORT_OPTIONS,
+                NEW_CELERY_worker_hijack_root_logger="false",
             )
         )
         self.assertEqual(
@@ -54,6 +55,7 @@ class TestNewCeleryConfig(unittest.TestCase):
                 broker_transport_options=dict(visibility_timeout=36000),
                 broker_url=BROKER_URL,
                 s3_bucket=S3_BUCKET,
+                worker_hijack_root_logger=False,
             ),
         )
 


### PR DESCRIPTION
Before this fix, it was not possible to set a configuration value that evaluates to `False` in Python.